### PR TITLE
Fix color encoding on ZSH

### DIFF
--- a/curltime.sh
+++ b/curltime.sh
@@ -43,13 +43,13 @@ function _divider
 function _colour {
   # set to green
   if [ $(bc <<< "$1 < 1") -eq 1 ]; then
-    echo -e  " \e[1;32m$1\e[m"
+    echo -e  " \033[1;32m$1\033[0m"
   # set to yellow
   elif [ $(bc <<< "$1 >= 0.300") -eq 1 ]; then
-    echo -e " \e[1;33m$1\e[m"
+    echo -e " \033[1;33m$1\033[0m"
   # set to red
   elif [ $(bc <<< "$1 > 0.400") -eq 1 ]; then
-    echo -e " \e[1;31m$1\e[m"
+    echo -e " \033[1;31m$1\033[0m"
   fi
 }
 


### PR DESCRIPTION
I use zsh shell in macOS ventura 13,
and come with this output :

<img width="775" alt="image" src="https://github.com/arzzen/curltime/assets/3290406/d468bb5b-67dd-4516-bb94-4e0e51c26258">

thus, this PR fix color encoding on zsh terminal.